### PR TITLE
feat: Workspace Changes Panel + Guided Onboarding (v0.1.26–0.1.27)

### DIFF
--- a/docs/wise-moseying-robin.md
+++ b/docs/wise-moseying-robin.md
@@ -1,0 +1,149 @@
+# Plan: Workspace Change History Panel
+
+## Context
+
+The old `workspace-vcs-design.md` focused on the git plumbing (init, commit, gitignore). This plan replaces it with a concrete UI + implementation spec.
+
+Agents naturally create/modify/delete files as they complete tasks. Users need to see what changed and explicitly "submit" those changes for safekeeping — without ever seeing git terminology.
+
+The Changes panel will live as a **tab in the existing right-sidebar (DirectoryPanel)**, alongside the current "Files" view, so users can toggle between exploring the file tree and reviewing pending works without leaving the Chat view.
+
+---
+
+## Terminology Map
+
+| Git concept | UI label |
+|---|---|
+| uncommitted / working tree changes | **Pending Works** |
+| `git commit` | **Submit** |
+| commit history | **History** |
+| untracked file | `+ New` |
+| modified file | `~ Modified` |
+| deleted file | `✕ Deleted` |
+
+---
+
+## UI Design
+
+### DirectoryPanel — new tab bar at top
+
+```
+┌─────────────────────────────────┐
+│  [📁 Files]  [🔄 Changes (3)]   │
+├─────────────────────────────────┤
+│  (existing file tree or         │
+│   new ChangesPanel below)       │
+└─────────────────────────────────┘
+```
+
+### Changes tab layout
+
+```
+┌─────────────────────────────────┐
+│  Pending Works (3)              │
+│  ────────────────────────────   │
+│  + src/NewComponent.tsx         │
+│  ~ src/api/client.ts            │
+│  ✕ docs/old-guide.md            │
+│                                 │
+│  [___Description (optional)___] │
+│  [        Submit         ]      │
+│                                 │
+│  History ─────────────────────  │
+│  ○ 2 min ago   "Checkpoint"  3↑ │
+│  ○ 2h ago      "Agent: fix"  1↑ │
+└─────────────────────────────────┘
+```
+
+- Badge on the "Changes" tab shows count of pending files
+- Badge disappears (or shows 0) when nothing is pending
+- History entries show: relative time, message, file count
+- No pending → show "All caught up" empty state
+- No git repo → show "VCS not initialized" with an [Initialize] button
+
+---
+
+## Implementation Plan
+
+### Phase 1 — Backend Git API (Bun sidecar)
+
+**New file:** `src/server/git.ts`
+
+Exports a Hono router mounted at `/api/git/` in `src/server/index.ts`.
+
+Endpoints:
+
+| Method | Path | Command | Response |
+|---|---|---|---|
+| GET | `/api/git/status` | `git status --porcelain` | `{ files: [{ path, status }] }` |
+| GET | `/api/git/log` | `git log --format=%H|%s|%ai|%an -n 30` | `{ entries: [{ hash, message, date, author, numFiles }] }` |
+| POST | `/api/git/submit` | `git add -A && git commit -m "..."` | `{ success, hash }` |
+| POST | `/api/git/init` | `git init && write .gitignore` | `{ initialized: bool }` |
+
+**Auto-init on sidecar startup** (in `src/server/index.ts` startup block):
+- If `workspacePath` is not under `/tmp` or `%TEMP%`
+- And `.git/` does not exist → call `git init` + write default `.gitignore`
+- Reuse the logic from `src/server/git.ts`
+
+`status` field values from `--porcelain`: `'?'` (new/untracked), `'M'` (modified), `'D'` (deleted).
+
+### Phase 2 — New React component
+
+**New file:** `src/renderer/components/WorkspaceChangesPanel.tsx`
+
+Uses Tab-scoped API (`useTabState` → `apiGet`, `apiPost`) to call the new git endpoints.
+
+State:
+- `pendingFiles: { path: string, status: 'new' | 'modified' | 'deleted' }[]`
+- `history: { hash: string, message: string, date: string, numFiles: number }[]`
+- `description: string` — optional submit message
+- `isSubmitting: boolean`
+- `isLoading: boolean`
+- `gitInitialized: boolean`
+
+Behavior:
+- Polls `GET /api/git/status` on mount and after each agent turn completes (listen to SSE `turn:complete` event or refresh key from parent)
+- Submit calls `POST /api/git/submit` with description (defaults to `"Checkpoint"` if empty)
+- After submit, re-fetch both status and log
+- [Initialize] button calls `POST /api/git/init` when git not set up
+
+### Phase 3 — Integrate into DirectoryPanel
+
+**File to modify:** `src/renderer/components/DirectoryPanel.tsx`
+
+Changes:
+1. Add local state `activeTab: 'files' | 'changes'`
+2. Add tab bar at top of panel (after title/header area) with:
+   - "Files" tab (existing content — no changes to file tree or AgentCapabilitiesPanel)
+   - "Changes" tab with a count badge (count from `pendingCount` prop or internal state)
+3. Render `<WorkspaceChangesPanel agentDir={agentDir} />` when `activeTab === 'changes'`
+4. Pass `agentDir` prop (already available in DirectoryPanel) into WorkspaceChangesPanel
+
+**No changes** to the existing file tree, AgentCapabilitiesPanel, or Chat.tsx layout.
+
+### Phase 4 — Update design doc
+
+Replace `docs/workspace-vcs-design.md` content with the finalized UI + API spec from this plan (terminology, endpoints, component structure) so the doc reflects what was actually built.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `src/server/git.ts` | New — git API router |
+| `src/server/index.ts` | Mount git router; add auto-init on startup |
+| `src/renderer/components/WorkspaceChangesPanel.tsx` | New — Changes UI component |
+| `src/renderer/components/DirectoryPanel.tsx` | Add tab bar + render ChangesPanel |
+| `docs/workspace-vcs-design.md` | Rewrite with final spec |
+
+---
+
+## Verification
+
+1. Open a workspace that has no `.git` → sidecar auto-inits → Changes tab shows "All caught up"
+2. Ask agent to create or edit a file → switch to Changes tab → see file in Pending Works with correct status badge
+3. Type a description, click Submit → success toast → Pending Works clears → History gains a new entry
+4. Click [Initialize] button on a workspace that git-failed to auto-init → `.git` appears on disk
+5. History entries show correct relative timestamps and file counts
+6. Tab badge on "Changes" shows live count; disappears when 0 pending

--- a/docs/workspace-vcs-design.md
+++ b/docs/workspace-vcs-design.md
@@ -1,0 +1,173 @@
+# Workspace Change History — UI & Implementation Spec
+
+> Status: Implemented in v0.1.25+
+
+## Overview
+
+Agents naturally create, modify, and delete files as they complete tasks. The Workspace Changes panel lets users review what changed and explicitly "submit" those changes for safekeeping — without ever seeing git terminology.
+
+The Changes panel lives as a **tab in the right-sidebar (DirectoryPanel)**, alongside the existing "Files" view.
+
+---
+
+## Terminology Map
+
+| Git concept | UI label |
+|---|---|
+| uncommitted / working tree changes | **Pending Works** |
+| `git commit` | **Submit** |
+| commit history | **History** |
+| untracked file | `+ New` |
+| modified file | `~ Modified` |
+| deleted file | `✕ Deleted` |
+
+---
+
+## UI Design
+
+### DirectoryPanel — tab bar at top
+
+```
+┌─────────────────────────────────┐
+│  [📁 Files]  [🔄 Changes (3)]   │
+├─────────────────────────────────┤
+│  (file tree or Changes panel)   │
+└─────────────────────────────────┘
+```
+
+### Changes tab layout
+
+```
+┌─────────────────────────────────┐
+│  Pending Works (3)              │
+│  ────────────────────────────   │
+│  + src/NewComponent.tsx         │
+│  ~ src/api/client.ts            │
+│  ✕ docs/old-guide.md            │
+│                                 │
+│  [___Description (optional)___] │
+│  [        Submit         ]      │
+│                                 │
+│  History ─────────────────────  │
+│  ○ 2 min ago   "Checkpoint"  3↑ │
+│  ○ 2h ago      "Agent: fix"  1↑ │
+└─────────────────────────────────┘
+```
+
+**Behavior:**
+- Badge on "Changes" tab shows count of pending files; disappears at 0
+- No pending → "All caught up" empty state
+- No git repo → "VCS not initialized" + [Initialize] button
+- History entries: relative time, message, file count
+
+---
+
+## Backend API (Bun Sidecar — `/api/git/`)
+
+All endpoints operate on the tab's `workspacePath` / `agentDir`.
+
+### `GET /api/git/status`
+
+Returns pending (uncommitted) file changes.
+
+**Response:**
+```json
+{
+  "files": [
+    { "path": "src/NewComponent.tsx", "status": "new" },
+    { "path": "src/api/client.ts", "status": "modified" },
+    { "path": "docs/old-guide.md", "status": "deleted" }
+  ],
+  "gitInitialized": true
+}
+```
+
+Status values map from `git status --porcelain`:
+- `??` → `"new"` (untracked)
+- `M` or `AM` → `"modified"`
+- `D` → `"deleted"`
+
+### `GET /api/git/log`
+
+Returns the last 30 commits.
+
+**Response:**
+```json
+{
+  "entries": [
+    { "hash": "abc123", "message": "Checkpoint", "date": "2025-01-01T10:00:00Z", "author": "MyAgents", "numFiles": 3 }
+  ],
+  "gitInitialized": true
+}
+```
+
+### `POST /api/git/submit`
+
+Stages all changes and creates a commit.
+
+**Request:** `{ "message": "optional description" }`  
+**Response:** `{ "success": true, "hash": "abc123" }` or `{ "success": false, "error": "..." }`
+
+Default message: `"Checkpoint"`
+
+### `POST /api/git/init`
+
+Initializes a git repository in the workspace.
+
+**Response:** `{ "initialized": true }`
+
+Also writes a default `.gitignore` and sets local git user config.
+
+---
+
+## Component Structure
+
+### `WorkspaceChangesPanel.tsx`
+
+- Uses Tab-scoped API (`useTabApi` / `apiGet`, `apiPost`) to call git endpoints
+- Polls `GET /api/git/status` on mount and after agent turn completes
+- Submit: `POST /api/git/submit` → re-fetches status + log
+- Initialize: `POST /api/git/init` → re-fetches status
+
+**State:**
+```typescript
+pendingFiles: { path: string, status: 'new' | 'modified' | 'deleted' }[]
+history: { hash: string, message: string, date: string, numFiles: number }[]
+description: string
+isSubmitting: boolean
+isLoading: boolean
+gitInitialized: boolean
+```
+
+### `DirectoryPanel.tsx` changes
+
+- Added `activeTab: 'files' | 'changes'` local state
+- Tab bar above existing content: "📁 Files" | "🔄 Changes (N)"
+- Renders `<WorkspaceChangesPanel agentDir={agentDir} />` when Changes tab active
+- No changes to file tree, AgentCapabilitiesPanel, or Chat layout
+
+---
+
+## Auto-Init
+
+On sidecar startup, if `workspacePath`:
+- Is not a temp directory (`/tmp`, `%TEMP%`)
+- Does not already have a `.git/` directory
+
+→ Automatically runs `git init` + writes `.gitignore`.
+
+---
+
+## Git Gitignore Defaults
+
+```gitignore
+node_modules/
+dist/
+build/
+.env
+*.log
+__pycache__/
+.DS_Store
+*.pyc
+.venv/
+```

--- a/setup.sh
+++ b/setup.sh
@@ -124,6 +124,13 @@ cd ..
 echo -e "${GREEN}✓ Rust 依赖准备完成${NC}"
 echo ""
 
+# 创建 Tauri 占位符资源 (tauri dev 需要，否则 build 失败)
+echo -e "${BLUE}[4.5/6] 创建 Tauri 占位符资源${NC}"
+mkdir -p "${PROJECT_DIR}/src-tauri/resources/claude-agent-sdk"
+echo "// dev placeholder" > "${PROJECT_DIR}/src-tauri/resources/server-dist.js"
+echo -e "${GREEN}✓ 占位符资源已创建${NC}"
+echo ""
+
 # 准备默认工作区 (mino) — 每次拉取最新版本
 # .git 不保留：避免 Tauri 资源打包权限问题 + rerun-if-changed 性能问题
 echo -e "${BLUE}[5/6] 准备默认工作区 (mino)${NC}"

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -23,6 +23,8 @@ import { type CronRecoverySummaryPayload, type CronTaskRecoveredPayload, CRON_EV
 import { isBrowserDevMode, isTauriEnvironment } from '@/utils/browserMock';
 import { forceFlushLogs, setLogServerUrl, clearLogServerUrl } from '@/utils/frontendLogger';
 import { CUSTOM_EVENTS, createPendingSessionId } from '../shared/constants';
+import { useOnboarding } from '@/hooks/useOnboarding';
+import OnboardingOverlay from '@/components/onboarding/OnboardingOverlay';
 
 // ============================================================
 // MemoizedTabContent — prevents re-rendering tabs whose props haven't changed.
@@ -140,6 +142,9 @@ export default function App() {
 
   // App config for tray behavior
   const { config, reload: reloadConfig } = useConfig();
+
+  // Onboarding state
+  const { isActive: isOnboardingActive, currentStep: onboardingStep, markStepComplete, skipOnboarding, trackPageVisit } = useOnboarding();
 
   // Listen for config changes from other components (e.g., Settings page)
   useEffect(() => {
@@ -1197,6 +1202,14 @@ export default function App() {
     // Global Sidecar is now started on App mount, no need to start here
   }, []);
 
+  // Navigate to the first launcher tab (for onboarding guidance)
+  const handleNavigateToLauncher = useCallback(() => {
+    const launcherTab = tabsRef.current.find(t => t.view === 'launcher');
+    if (launcherTab) {
+      setActiveTabId(launcherTab.id);
+    }
+  }, []);
+
   // Listen for OPEN_SETTINGS custom event from child components
   useEffect(() => {
     const handleOpenSettingsEvent = (event: CustomEvent<{ section?: string }>) => {
@@ -1232,6 +1245,17 @@ export default function App() {
   // With Session-centric Sidecar (Owner model), stopping a cron task only releases
   // the CronTask owner. If Tab still owns the Sidecar, it continues running.
   // No SSE reconnection or Sidecar restart is needed.
+
+  // Track page visits for onboarding
+  useEffect(() => {
+    const activeTab = tabsRef.current.find(t => t.id === activeTabId);
+    if (!activeTab) return;
+    if (activeTab.view === 'settings') {
+      trackPageVisit('settings');
+    } else if (activeTab.view === 'launcher') {
+      trackPageVisit('launcher');
+    }
+  }, [activeTabId, trackPageVisit]);
 
   // Stable callback for Settings onSectionChange — avoids inline arrow creating new ref every render
   const handleSettingsSectionChange = useCallback(() => {
@@ -1313,6 +1337,18 @@ export default function App() {
           />
         ))}
       </div>
+
+      {/* Onboarding spotlight overlay */}
+      {isOnboardingActive && (
+        <OnboardingOverlay
+          currentStep={onboardingStep}
+          activeTabView={tabs.find(t => t.id === activeTabId)?.view ?? 'launcher'}
+          onNavigateToSettings={() => handleOpenSettings('providers')}
+          onNavigateToLauncher={handleNavigateToLauncher}
+          onStepComplete={markStepComplete}
+          onSkip={skipOnboarding}
+        />
+      )}
 
       {/* Close confirmation dialog */}
       {closeConfirmState && (

--- a/src/renderer/components/DirectoryPanel.tsx
+++ b/src/renderer/components/DirectoryPanel.tsx
@@ -1266,6 +1266,7 @@ const DirectoryPanel = memo(forwardRef<DirectoryPanelHandle, DirectoryPanelProps
               agentDir={agentDir}
               refreshTrigger={refreshTrigger}
               onPendingCountChange={setPendingCount}
+              onFilesChanged={refresh}
             />
           )}
         </>

--- a/src/renderer/components/DirectoryPanel.tsx
+++ b/src/renderer/components/DirectoryPanel.tsx
@@ -35,6 +35,7 @@ import ConfirmDialog from './ConfirmDialog';
 import ContextMenu, { type ContextMenuItem } from './ContextMenu';
 import RenameDialog from './RenameDialog';
 import AgentCapabilitiesPanel from './AgentCapabilitiesPanel';
+import WorkspaceChangesPanel from './WorkspaceChangesPanel';
 import type { Tab as WorkspaceTab } from './WorkspaceConfigPanel';
 
 // Lazy load FilePreviewModal - it includes heavy SyntaxHighlighter
@@ -162,6 +163,8 @@ const DirectoryPanel = memo(forwardRef<DirectoryPanelHandle, DirectoryPanelProps
   // Narrow mode collapse state (for responsive layout)
   const [isNarrowMode, setIsNarrowMode] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(true); // Default collapsed in narrow mode
+  const [activeTab, setActiveTab] = useState<'files' | 'changes'>('files');
+  const [pendingCount, setPendingCount] = useState(0);
   const panelRef = useRef<HTMLDivElement>(null);
 
   // Detect narrow mode (when panel becomes full width, i.e. stacked layout)
@@ -1038,6 +1041,36 @@ const DirectoryPanel = memo(forwardRef<DirectoryPanelHandle, DirectoryPanelProps
             />
           </div>
 
+          {/* Tab bar: Files / Changes */}
+          <div className="flex border-b border-[var(--line)] shrink-0">
+            <button
+              onClick={() => setActiveTab('files')}
+              className={`flex items-center gap-1 px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
+                activeTab === 'files'
+                  ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                  : 'border-transparent text-[var(--ink-muted)] hover:text-[var(--ink)]'
+              }`}
+            >
+              📁 Files
+            </button>
+            <button
+              onClick={() => setActiveTab('changes')}
+              className={`flex items-center gap-1 px-3 py-2 text-sm font-medium border-b-2 transition-colors ${
+                activeTab === 'changes'
+                  ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                  : 'border-transparent text-[var(--ink-muted)] hover:text-[var(--ink)]'
+              }`}
+            >
+              🔄 Changes{pendingCount > 0 && (
+                <span className="ml-1 bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300 text-xs rounded-full px-1.5 py-0.5">
+                  {pendingCount}
+                </span>
+              )}
+            </button>
+          </div>
+
+          {activeTab === 'files' ? (
+          <>
           {/* Tree + Capabilities container (60/40 split) */}
           <div className="flex min-h-0 flex-1 flex-col">
             {/* Tree container */}
@@ -1227,6 +1260,14 @@ const DirectoryPanel = memo(forwardRef<DirectoryPanelHandle, DirectoryPanelProps
               onExpandChange={updateTreeHeight}
             />
           </div>
+          </>
+          ) : (
+            <WorkspaceChangesPanel
+              agentDir={agentDir}
+              refreshTrigger={refreshTrigger}
+              onPendingCountChange={setPendingCount}
+            />
+          )}
         </>
       )}
 

--- a/src/renderer/components/WorkspaceChangesPanel.tsx
+++ b/src/renderer/components/WorkspaceChangesPanel.tsx
@@ -1,0 +1,432 @@
+/**
+ * WorkspaceChangesPanel - Git-backed workspace change history panel
+ *
+ * Shows:
+ * - Pending (unstaged/staged) file changes with status badges
+ * - A description input + Submit button to create a checkpoint commit
+ * - Commit history log with relative timestamps
+ * - An Initialize button when the workspace has no git repo yet
+ */
+import { GitBranch, Loader2, RefreshCw, RotateCcw } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useTabApi } from '@/context/TabContext';
+import { useToast } from '@/components/Toast';
+
+// ─── Types (mirrors server/git.ts) ───────────────────────────────────────────
+
+interface PendingFile {
+    path: string;
+    status: 'new' | 'modified' | 'deleted';
+}
+
+interface HistoryEntry {
+    hash: string;
+    message: string;
+    date: string;
+    numFiles: number;
+}
+
+interface GitStatusResponse {
+    files: PendingFile[];
+    gitInitialized?: boolean;
+}
+
+interface GitLogResponse {
+    entries: HistoryEntry[];
+    gitInitialized?: boolean;
+}
+
+interface GitSubmitResponse {
+    success: boolean;
+    hash?: string;
+    error?: string;
+}
+
+interface GitInitResponse {
+    initialized: boolean;
+}
+
+interface GitRevertResponse {
+    success: boolean;
+    error?: string;
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface WorkspaceChangesPanelProps {
+    agentDir: string;
+    /** Increment this from the parent to trigger a refresh (e.g. on turn:complete) */
+    refreshTrigger?: number;
+    /** Called whenever the pending file count changes, for badge display */
+    onPendingCountChange?: (count: number) => void;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatRelativeTime(dateStr: string): string {
+    const date = new Date(dateStr);
+    if (isNaN(date.getTime())) return dateStr;
+
+    const diffMs = Date.now() - date.getTime();
+    const diffSec = Math.floor(diffMs / 1000);
+    const diffMin = Math.floor(diffSec / 60);
+    const diffHr = Math.floor(diffMin / 60);
+    const diffDay = Math.floor(diffHr / 24);
+
+    if (diffMin < 1) return 'just now';
+    if (diffHr < 1) return `${diffMin} min ago`;
+    if (diffDay < 1) return `${diffHr}h ago`;
+    return `${diffDay}d ago`;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function WorkspaceChangesPanel({
+    agentDir,
+    refreshTrigger = 0,
+    onPendingCountChange,
+}: WorkspaceChangesPanelProps) {
+    const { apiGet, apiPost } = useTabApi();
+    const toast = useToast();
+    const toastRef = useRef(toast);
+    toastRef.current = toast;
+    const onPendingCountChangeRef = useRef(onPendingCountChange);
+    onPendingCountChangeRef.current = onPendingCountChange;
+
+    const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);
+    const [history, setHistory] = useState<HistoryEntry[]>([]);
+    const [description, setDescription] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [isReverting, setIsReverting] = useState(false);
+    const [revertingFile, setRevertingFile] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [gitInitialized, setGitInitialized] = useState(true);
+
+    const isMountedRef = useRef(true);
+    useEffect(() => {
+        isMountedRef.current = true;
+        return () => { isMountedRef.current = false; };
+    }, []);
+
+    // ── Data fetching ──────────────────────────────────────────────────────────
+
+    const fetchStatus = useCallback(async () => {
+        try {
+            const res = await apiGet<GitStatusResponse>('/api/git/status');
+            if (!isMountedRef.current) return;
+            // gitInitialized is undefined (true) when the repo exists; false when not
+            setGitInitialized(res.gitInitialized !== false);
+            const files = res.files ?? [];
+            setPendingFiles(files);
+            onPendingCountChangeRef.current?.(files.length);
+        } catch (err) {
+            if (!isMountedRef.current) return;
+            console.error('[WorkspaceChangesPanel] status fetch failed:', err);
+        }
+    }, [apiGet]);
+
+    const fetchLog = useCallback(async () => {
+        try {
+            const res = await apiGet<GitLogResponse>('/api/git/log');
+            if (!isMountedRef.current) return;
+            setHistory(res.entries ?? []);
+        } catch (err) {
+            if (!isMountedRef.current) return;
+            console.error('[WorkspaceChangesPanel] log fetch failed:', err);
+        }
+    }, [apiGet]);
+
+    const refresh = useCallback(async () => {
+        setIsLoading(true);
+        await Promise.all([fetchStatus(), fetchLog()]);
+        if (isMountedRef.current) setIsLoading(false);
+    }, [fetchStatus, fetchLog]);
+
+    useEffect(() => {
+        void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [refreshTrigger]);  // refresh is stable (useCallback with stable deps), but we intentionally only re-run on refreshTrigger change
+
+    // ── Actions ────────────────────────────────────────────────────────────────
+
+    const handleSubmit = useCallback(async () => {
+        setIsSubmitting(true);
+        try {
+            const res = await apiPost<GitSubmitResponse>('/api/git/submit', {
+                message: description.trim() || 'Checkpoint',
+                workspacePath: agentDir,
+            });
+            if (!isMountedRef.current) return;
+            if (res.success) {
+                setDescription('');
+                toastRef.current.success('Checkpoint saved');
+                await Promise.all([fetchStatus(), fetchLog()]);
+            } else {
+                toastRef.current.error(res.error ?? 'Submit failed');
+            }
+        } catch (err) {
+            if (!isMountedRef.current) return;
+            console.error('[WorkspaceChangesPanel] submit failed:', err);
+            toastRef.current.error('Submit failed, please retry');
+        } finally {
+            if (isMountedRef.current) setIsSubmitting(false);
+        }
+    }, [apiPost, agentDir, description, fetchStatus, fetchLog]);
+
+    const handleInit = useCallback(async () => {
+        try {
+            await apiPost<GitInitResponse>('/api/git/init', { workspacePath: agentDir });
+            if (!isMountedRef.current) return;
+            toastRef.current.success('Version control initialized');
+            await refresh();
+        } catch (err) {
+            if (!isMountedRef.current) return;
+            console.error('[WorkspaceChangesPanel] init failed:', err);
+            toastRef.current.error('Initialization failed, please retry');
+        }
+    }, [apiPost, agentDir, refresh]);
+
+    const handleRevertFile = useCallback(async (filePath: string) => {
+        setRevertingFile(filePath);
+        try {
+            const res = await apiPost<GitRevertResponse>('/api/git/revert', {
+                workspacePath: agentDir,
+                filePath,
+            });
+            if (!isMountedRef.current) return;
+            if (res.success) {
+                toastRef.current.success('File reverted');
+                await fetchStatus();
+            } else {
+                toastRef.current.error(res.error ?? 'Revert failed');
+            }
+        } catch (err) {
+            if (!isMountedRef.current) return;
+            console.error('[WorkspaceChangesPanel] revert file failed:', err);
+            toastRef.current.error('Revert failed, please retry');
+        } finally {
+            if (isMountedRef.current) setRevertingFile(null);
+        }
+    }, [apiPost, agentDir, fetchStatus]);
+
+    const handleRevertAll = useCallback(async () => {
+        setIsReverting(true);
+        try {
+            const res = await apiPost<GitRevertResponse>('/api/git/revert', {
+                workspacePath: agentDir,
+            });
+            if (!isMountedRef.current) return;
+            if (res.success) {
+                toastRef.current.success('All changes reverted');
+                await fetchStatus();
+            } else {
+                toastRef.current.error(res.error ?? 'Revert failed');
+            }
+        } catch (err) {
+            if (!isMountedRef.current) return;
+            console.error('[WorkspaceChangesPanel] revert all failed:', err);
+            toastRef.current.error('Revert failed, please retry');
+        } finally {
+            if (isMountedRef.current) setIsReverting(false);
+        }
+    }, [apiPost, agentDir, fetchStatus]);
+
+    // ── Render ─────────────────────────────────────────────────────────────────
+
+    if (isLoading) {
+        return (
+            <div className="flex items-center gap-2 px-3 py-4 text-base text-[var(--ink-muted)]">
+                <Loader2 className="h-5 w-5 animate-spin" />
+                <span>Loading...</span>
+            </div>
+        );
+    }
+
+    if (!gitInitialized) {
+        return (
+            <div className="px-3 py-4">
+                <div className="mb-3 flex items-center gap-2 text-base text-[var(--ink-muted)]">
+                    <GitBranch className="h-5 w-5 shrink-0" />
+                    <span>VCS not initialized</span>
+                </div>
+                <p className="mb-3 text-sm text-[var(--ink-faint)]">
+                    Initialize version control to track workspace changes and create checkpoints.
+                </p>
+                <button
+                    onClick={handleInit}
+                    className="rounded-md bg-[var(--accent)] px-4 py-2 text-sm font-medium text-white hover:opacity-90 active:opacity-80"
+                >
+                    Initialize
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-4 px-3 py-3">
+            {/* ── Pending Changes ── */}
+            <section>
+                <div className="mb-2 flex items-center justify-between">
+                    <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--ink-muted)]">
+                        Pending Works
+                        {pendingFiles.length > 0 && (
+                            <span className="ml-1.5 rounded-full bg-[var(--paper-contrast)] px-1.5 py-0.5 text-xs font-normal">
+                                {pendingFiles.length}
+                            </span>
+                        )}
+                    </h3>
+                    <div className="flex items-center gap-1">
+                        {pendingFiles.length > 0 && (
+                            <button
+                                onClick={handleRevertAll}
+                                disabled={isReverting}
+                                title="Revert all changes"
+                                className="flex items-center gap-1 rounded px-2 py-1 text-xs text-red-500 hover:bg-red-50 hover:text-red-600 active:opacity-80 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-red-900/20"
+                            >
+                                {isReverting
+                                    ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                    : <RotateCcw className="h-3.5 w-3.5" />
+                                }
+                                <span>Revert All</span>
+                            </button>
+                        )}
+                        <button
+                            onClick={refresh}
+                            title="Refresh"
+                            className="rounded p-1 text-[var(--ink-faint)] hover:text-[var(--ink-muted)]"
+                        >
+                            <RefreshCw className="h-3.5 w-3.5" />
+                        </button>
+                    </div>
+                </div>
+
+                {pendingFiles.length === 0 ? (
+                    <p className="text-sm text-[var(--ink-faint)]">All caught up ✓</p>
+                ) : (
+                    <>
+                        <ul className="mb-3 space-y-1.5">
+                            {pendingFiles.map((file) => (
+                                <PendingFileRow
+                                    key={file.path}
+                                    file={file}
+                                    isReverting={revertingFile === file.path}
+                                    onRevert={handleRevertFile}
+                                />
+                            ))}
+                        </ul>
+
+                        {/* Submit form */}
+                        <div className="flex flex-col gap-2">
+                            <input
+                                type="text"
+                                value={description}
+                                onChange={(e) => setDescription(e.target.value)}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' && !isSubmitting) void handleSubmit();
+                                }}
+                                placeholder="Description (optional)"
+                                className="w-full rounded-md border border-[var(--line)] bg-[var(--input-bg)] px-3 py-2 text-sm text-[var(--ink)] placeholder:text-[var(--ink-faint)] focus:border-[var(--accent)] focus:outline-none"
+                            />
+                            <button
+                                onClick={handleSubmit}
+                                disabled={isSubmitting}
+                                className="flex items-center justify-center gap-1.5 rounded-md bg-[var(--accent)] px-3 py-2 text-sm font-medium text-white hover:opacity-90 active:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                {isSubmitting && <Loader2 className="h-4 w-4 animate-spin" />}
+                                Submit
+                            </button>
+                        </div>
+                    </>
+                )}
+            </section>
+
+            {/* Divider */}
+            <div className="border-t border-[var(--line)]" />
+
+            {/* ── History ── */}
+            <section>
+                <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-[var(--ink-muted)]">
+                    History
+                </h3>
+
+                {history.length === 0 ? (
+                    <p className="text-sm text-[var(--ink-faint)]">No history yet</p>
+                ) : (
+                    <ul className="space-y-2">
+                        {history.map((entry) => (
+                            <HistoryEntryRow key={entry.hash} entry={entry} />
+                        ))}
+                    </ul>
+                )}
+            </section>
+        </div>
+    );
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function PendingFileRow({
+    file,
+    isReverting,
+    onRevert,
+}: {
+    file: PendingFile;
+    isReverting: boolean;
+    onRevert: (path: string) => void;
+}) {
+    const { prefix, colorClass } = STATUS_META[file.status];
+    return (
+        <li className="flex items-center gap-2 text-sm">
+            <span className={`shrink-0 font-mono font-semibold ${colorClass}`}>{prefix}</span>
+            <span className="min-w-0 truncate text-[var(--ink)]" title={file.path}>
+                {file.path}
+            </span>
+            <span className={`shrink-0 text-xs ${colorClass}`}>
+                {STATUS_LABELS[file.status]}
+            </span>
+            <button
+                onClick={() => onRevert(file.path)}
+                disabled={isReverting}
+                title={`Revert ${file.path}`}
+                className="ml-1 shrink-0 rounded p-0.5 text-[var(--ink-faint)] hover:text-red-500 active:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+                {isReverting
+                    ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    : <RotateCcw className="h-3.5 w-3.5" />
+                }
+            </button>
+        </li>
+    );
+}
+
+function HistoryEntryRow({ entry }: { entry: HistoryEntry }) {
+    return (
+        <li className="flex items-start gap-2 text-sm text-[var(--ink-muted)]">
+            <span className="mt-0.5 shrink-0 text-[var(--ink-faint)]">●</span>
+            <span className="shrink-0 tabular-nums text-[var(--ink-faint)]">
+                {formatRelativeTime(entry.date)}
+            </span>
+            <span className="min-w-0 truncate" title={entry.message}>
+                &ldquo;{entry.message}&rdquo;
+            </span>
+            <span className="ml-auto shrink-0 text-[var(--ink-faint)]">
+                {entry.numFiles} {entry.numFiles === 1 ? 'file' : 'files'}
+            </span>
+        </li>
+    );
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const STATUS_META: Record<PendingFile['status'], { prefix: string; colorClass: string }> = {
+    new: { prefix: '+', colorClass: 'text-green-600' },
+    modified: { prefix: '~', colorClass: 'text-yellow-600' },
+    deleted: { prefix: '✕', colorClass: 'text-red-600' },
+};
+
+const STATUS_LABELS: Record<PendingFile['status'], string> = {
+    new: 'New',
+    modified: 'Modified',
+    deleted: 'Deleted',
+};

--- a/src/renderer/components/WorkspaceChangesPanel.tsx
+++ b/src/renderer/components/WorkspaceChangesPanel.tsx
@@ -62,6 +62,13 @@ interface WorkspaceChangesPanelProps {
     onPendingCountChange?: (count: number) => void;
 }
 
+// Maps file status to a human-readable verb used in toast messages
+const REVERT_VERB: Record<PendingFile['status'], string> = {
+    deleted: 'Restored',
+    modified: 'Discarded',
+    new: 'Removed',
+};
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function formatRelativeTime(dateStr: string): string {
@@ -187,7 +194,7 @@ export default function WorkspaceChangesPanel({
         }
     }, [apiPost, agentDir, refresh]);
 
-    const handleRevertFile = useCallback(async (filePath: string) => {
+    const handleRevertFile = useCallback(async (filePath: string, fileStatus: PendingFile['status']) => {
         setRevertingFile(filePath);
         try {
             const res = await apiPost<GitRevertResponse>('/api/git/revert', {
@@ -196,7 +203,7 @@ export default function WorkspaceChangesPanel({
             });
             if (!isMountedRef.current) return;
             if (res.success) {
-                toastRef.current.success('File reverted');
+                toastRef.current.success(`${REVERT_VERB[fileStatus]}: ${filePath}`);
                 await fetchStatus();
             } else {
                 toastRef.current.error(res.error ?? 'Revert failed');
@@ -311,7 +318,7 @@ export default function WorkspaceChangesPanel({
                                     key={file.path}
                                     file={file}
                                     isReverting={revertingFile === file.path}
-                                    onRevert={handleRevertFile}
+                                    onRevert={(path) => handleRevertFile(path, file.status)}
                                 />
                             ))}
                         </ul>
@@ -388,7 +395,7 @@ function PendingFileRow({
             <button
                 onClick={() => onRevert(file.path)}
                 disabled={isReverting}
-                title={`Revert ${file.path}`}
+                title={file.status === 'deleted' ? `Restore ${file.path}` : `Discard changes to ${file.path}`}
                 className="ml-1 shrink-0 rounded p-0.5 text-[var(--ink-faint)] hover:text-red-500 active:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
             >
                 {isReverting

--- a/src/renderer/components/WorkspaceChangesPanel.tsx
+++ b/src/renderer/components/WorkspaceChangesPanel.tsx
@@ -60,6 +60,8 @@ interface WorkspaceChangesPanelProps {
     refreshTrigger?: number;
     /** Called whenever the pending file count changes, for badge display */
     onPendingCountChange?: (count: number) => void;
+    /** Called after a revert or submit so the Files tab can refresh its tree */
+    onFilesChanged?: () => void;
 }
 
 // Maps file status to a human-readable verb used in toast messages
@@ -93,6 +95,7 @@ export default function WorkspaceChangesPanel({
     agentDir,
     refreshTrigger = 0,
     onPendingCountChange,
+    onFilesChanged,
 }: WorkspaceChangesPanelProps) {
     const { apiGet, apiPost } = useTabApi();
     const toast = useToast();
@@ -100,6 +103,8 @@ export default function WorkspaceChangesPanel({
     toastRef.current = toast;
     const onPendingCountChangeRef = useRef(onPendingCountChange);
     onPendingCountChangeRef.current = onPendingCountChange;
+    const onFilesChangedRef = useRef(onFilesChanged);
+    onFilesChangedRef.current = onFilesChanged;
 
     const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);
     const [history, setHistory] = useState<HistoryEntry[]>([]);
@@ -168,6 +173,7 @@ export default function WorkspaceChangesPanel({
             if (res.success) {
                 setDescription('');
                 toastRef.current.success('Checkpoint saved');
+                onFilesChangedRef.current?.();
                 await Promise.all([fetchStatus(), fetchLog()]);
             } else {
                 toastRef.current.error(res.error ?? 'Submit failed');
@@ -204,6 +210,7 @@ export default function WorkspaceChangesPanel({
             if (!isMountedRef.current) return;
             if (res.success) {
                 toastRef.current.success(`${REVERT_VERB[fileStatus]}: ${filePath}`);
+                onFilesChangedRef.current?.();
                 await fetchStatus();
             } else {
                 toastRef.current.error(res.error ?? 'Revert failed');
@@ -226,6 +233,7 @@ export default function WorkspaceChangesPanel({
             if (!isMountedRef.current) return;
             if (res.success) {
                 toastRef.current.success('All changes reverted');
+                onFilesChangedRef.current?.();
                 await fetchStatus();
             } else {
                 toastRef.current.error(res.error ?? 'Revert failed');

--- a/src/renderer/components/launcher/BrandSection.tsx
+++ b/src/renderer/components/launcher/BrandSection.tsx
@@ -67,7 +67,7 @@ export default memo(function BrandSection({
     }, [onSend]);
 
     return (
-        <section className="flex flex-1 flex-col items-center px-12">
+        <section data-onboarding-id="brand-section" className="flex flex-1 flex-col items-center px-12">
             {/* Upper area: Brand Name + Slogans */}
             <div className="flex flex-1 flex-col items-center justify-center">
                 <h1 className="brand-title mb-5 text-[2.75rem] font-light tracking-[0.04em] text-[var(--ink)] md:text-[3.5rem]">
@@ -80,7 +80,7 @@ export default memo(function BrandSection({
 
             {/* Lower area: Input box with workspace selector in toolbar */}
             <div className="mt-10 w-full max-w-[640px] pb-[12vh]">
-                <div className="relative w-full">
+                <div data-onboarding-id="instruction-input" className="relative w-full">
                     <SimpleChatInput
                         mode="launcher"
                         onSend={handleSend}

--- a/src/renderer/components/onboarding/OnboardingOverlay.tsx
+++ b/src/renderer/components/onboarding/OnboardingOverlay.tsx
@@ -1,0 +1,270 @@
+/**
+ * OnboardingOverlay - Spotlight overlay for guided onboarding
+ *
+ * Uses the inverted box-shadow technique to create a spotlight:
+ *   A fixed div over the target element with box-shadow: 0 0 0 9999px rgba(0,0,0,0.6)
+ *   dims everything outside while keeping the target interactive (pointer-events: none).
+ *
+ * When the target element is not in DOM (wrong page), shows a floating nav guide card.
+ */
+
+import { useLayoutEffect, useRef, useState, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { ONBOARDING_STEPS } from '../../../shared/constants';
+
+interface StepDef {
+  targetId: string;
+  requiredView: 'settings' | 'launcher';
+  title: string;
+  description: string;
+  tooltipSide: 'top' | 'bottom' | 'left' | 'right';
+  manualAdvance?: boolean;
+  navLabel: string;
+}
+
+const STEPS: StepDef[] = [
+  {
+    targetId: 'providers-section',
+    requiredView: 'settings',
+    title: '配置 AI 供应商',
+    description: '选择一个供应商并输入 API Key 以开始使用 MyAgents',
+    tooltipSide: 'bottom',
+    navLabel: '前往设置',
+  },
+  {
+    targetId: 'add-workspace',
+    requiredView: 'launcher',
+    title: '添加工作区',
+    description: '点击这里选择一个文件夹作为您的第一个工作区',
+    tooltipSide: 'left',
+    navLabel: '前往首页',
+  },
+  {
+    targetId: 'brand-section',
+    requiredView: 'launcher',
+    title: '您的 Agent 中心',
+    description: '这里是与 AI Agent 对话的地方。选好工作区，输入任务即可开始',
+    tooltipSide: 'right',
+    manualAdvance: true,
+    navLabel: '前往首页',
+  },
+  {
+    targetId: 'instruction-input',
+    requiredView: 'launcher',
+    title: '发送第一个指令',
+    description: '告诉 Agent 您想完成什么，按 Enter 或点击发送按钮',
+    tooltipSide: 'top',
+    navLabel: '前往首页',
+  },
+];
+
+interface TargetRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+interface OnboardingOverlayProps {
+  currentStep: number;
+  activeTabView: 'launcher' | 'settings' | 'chat';
+  onNavigateToSettings: () => void;
+  onNavigateToLauncher: () => void;
+  onStepComplete: () => Promise<void>;
+  onSkip: () => Promise<void>;
+}
+
+const SPOTLIGHT_PADDING = 6;
+const TOOLTIP_GAP = 12;
+
+export default function OnboardingOverlay({
+  currentStep,
+  activeTabView,
+  onNavigateToSettings,
+  onNavigateToLauncher,
+  onStepComplete,
+  onSkip,
+}: OnboardingOverlayProps) {
+  const [targetRect, setTargetRect] = useState<TargetRect | null>(null);
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  const stepDef = STEPS[currentStep];
+
+  // Measure target element position
+  const measureTarget = useCallback(() => {
+    if (!stepDef) return;
+    const el = document.querySelector(`[data-onboarding-id="${stepDef.targetId}"]`);
+    if (!el) {
+      setTargetRect(null);
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    setTargetRect({ top: rect.top, left: rect.left, width: rect.width, height: rect.height });
+  }, [stepDef]);
+
+  useLayoutEffect(() => {
+    // Schedule initial measurement asynchronously to avoid synchronous setState in effect body
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(measureTarget);
+
+    // Watch for resize/layout changes
+    const el = stepDef
+      ? document.querySelector(`[data-onboarding-id="${stepDef.targetId}"]`)
+      : null;
+
+    if (el) {
+      observerRef.current = new ResizeObserver(() => {
+        if (rafRef.current) cancelAnimationFrame(rafRef.current);
+        rafRef.current = requestAnimationFrame(measureTarget);
+      });
+      observerRef.current.observe(el);
+      observerRef.current.observe(document.documentElement);
+    }
+
+    const handleResize = () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(measureTarget);
+    };
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      window.removeEventListener('resize', handleResize);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- stepDef is a derived constant from STEPS[currentStep]; currentStep already triggers re-run via measureTarget dep
+  }, [measureTarget, currentStep]);
+
+  if (!stepDef) return null;
+
+  const isWrongPage = activeTabView !== stepDef.requiredView;
+  const navigate = stepDef.requiredView === 'settings' ? onNavigateToSettings : onNavigateToLauncher;
+
+  // Wrong page: show floating guide card
+  if (isWrongPage || !targetRect) {
+    return createPortal(
+      <div
+        className="fixed bottom-8 right-8 z-[500] animate-onboarding-appear"
+        role="dialog"
+        aria-label="引导提示"
+      >
+        <div
+          className="glass-panel p-4 max-w-[260px] flex flex-col gap-3"
+          style={{ boxShadow: '0 4px 24px rgba(0,0,0,0.18)' }}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <span className="badge text-xs">
+              {currentStep + 1} / {ONBOARDING_STEPS.TOTAL}
+            </span>
+            <button
+              onClick={() => void onSkip()}
+              className="text-[var(--ink-subtle)] hover:text-[var(--ink-muted)] text-xs transition-colors"
+            >
+              跳过引导
+            </button>
+          </div>
+          <p className="text-sm font-medium text-[var(--ink)]">{stepDef.title}</p>
+          <p className="text-xs text-[var(--ink-muted)] leading-relaxed">{stepDef.description}</p>
+          <button
+            onClick={navigate}
+            className="action-button w-full text-center text-sm py-1.5"
+          >
+            {stepDef.navLabel} →
+          </button>
+        </div>
+      </div>,
+      document.body
+    );
+  }
+
+  // Spotlight dimensions (add padding around target)
+  const spotTop = targetRect.top - SPOTLIGHT_PADDING;
+  const spotLeft = targetRect.left - SPOTLIGHT_PADDING;
+  const spotWidth = targetRect.width + SPOTLIGHT_PADDING * 2;
+  const spotHeight = targetRect.height + SPOTLIGHT_PADDING * 2;
+
+  // Tooltip position calculation
+  const tooltipStyle = computeTooltipStyle(stepDef.tooltipSide, spotTop, spotLeft, spotWidth, spotHeight);
+
+  return createPortal(
+    <>
+      {/* Spotlight div — inverted box-shadow dims everything outside */}
+      <div
+        style={{
+          position: 'fixed',
+          top: spotTop,
+          left: spotLeft,
+          width: spotWidth,
+          height: spotHeight,
+          boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.55)',
+          borderRadius: 8,
+          zIndex: 500,
+          pointerEvents: 'none',
+        }}
+        aria-hidden="true"
+      />
+
+      {/* Tooltip card */}
+      <div
+        className="animate-onboarding-appear"
+        style={{
+          position: 'fixed',
+          zIndex: 501,
+          ...tooltipStyle,
+        }}
+        role="dialog"
+        aria-label="引导提示"
+      >
+        <div
+          className="glass-panel p-4 flex flex-col gap-3"
+          style={{ maxWidth: 280, boxShadow: '0 4px 24px rgba(0,0,0,0.18)' }}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <span className="badge text-xs">
+              {currentStep + 1} / {ONBOARDING_STEPS.TOTAL}
+            </span>
+            <button
+              onClick={() => void onSkip()}
+              className="text-[var(--ink-subtle)] hover:text-[var(--ink-muted)] text-xs transition-colors"
+            >
+              跳过
+            </button>
+          </div>
+          <p className="text-sm font-semibold text-[var(--ink)]">{stepDef.title}</p>
+          <p className="text-xs text-[var(--ink-muted)] leading-relaxed">{stepDef.description}</p>
+          {stepDef.manualAdvance && (
+            <button
+              onClick={() => void onStepComplete()}
+              className="action-button w-full text-center text-sm py-1.5"
+            >
+              下一步 →
+            </button>
+          )}
+        </div>
+      </div>
+    </>,
+    document.body
+  );
+}
+
+function computeTooltipStyle(
+  side: 'top' | 'bottom' | 'left' | 'right',
+  spotTop: number,
+  spotLeft: number,
+  spotWidth: number,
+  spotHeight: number
+): React.CSSProperties {
+  const gap = TOOLTIP_GAP;
+  switch (side) {
+    case 'bottom':
+      return { top: spotTop + spotHeight + gap, left: spotLeft };
+    case 'top':
+      return { bottom: window.innerHeight - spotTop + gap, left: spotLeft };
+    case 'right':
+      return { top: spotTop, left: spotLeft + spotWidth + gap };
+    case 'left':
+      return { top: spotTop, right: window.innerWidth - spotLeft + gap };
+  }
+}

--- a/src/renderer/components/onboarding/OnboardingOverlay.tsx
+++ b/src/renderer/components/onboarding/OnboardingOverlay.tsx
@@ -87,6 +87,7 @@ export default function OnboardingOverlay({
 }: OnboardingOverlayProps) {
   const [targetRect, setTargetRect] = useState<TargetRect | null>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
+  const mutationObserverRef = useRef<MutationObserver | null>(null);
   const rafRef = useRef<number | null>(null);
 
   const stepDef = STEPS[currentStep];
@@ -120,6 +121,17 @@ export default function OnboardingOverlay({
       });
       observerRef.current.observe(el);
       observerRef.current.observe(document.documentElement);
+    } else if (stepDef) {
+      // Element not in DOM yet (e.g. async load). Watch for it to appear.
+      mutationObserverRef.current = new MutationObserver(() => {
+        const appeared = document.querySelector(`[data-onboarding-id="${stepDef.targetId}"]`);
+        if (!appeared) return;
+        mutationObserverRef.current?.disconnect();
+        mutationObserverRef.current = null;
+        if (rafRef.current) cancelAnimationFrame(rafRef.current);
+        rafRef.current = requestAnimationFrame(measureTarget);
+      });
+      mutationObserverRef.current.observe(document.body, { childList: true, subtree: true });
     }
 
     const handleResize = () => {
@@ -131,11 +143,13 @@ export default function OnboardingOverlay({
     return () => {
       observerRef.current?.disconnect();
       observerRef.current = null;
+      mutationObserverRef.current?.disconnect();
+      mutationObserverRef.current = null;
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
       window.removeEventListener('resize', handleResize);
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- stepDef is a derived constant from STEPS[currentStep]; currentStep already triggers re-run via measureTarget dep
-  }, [measureTarget, currentStep]);
+  // activeTabView triggers re-measure when user navigates to the required page
+  }, [measureTarget, currentStep, activeTabView]);
 
   if (!stepDef) return null;
 

--- a/src/renderer/config/types.ts
+++ b/src/renderer/config/types.ts
@@ -212,6 +212,20 @@ export interface ProxySettings {
 }
 
 /**
+ * Onboarding progress tracking (stored in AppConfig)
+ * undefined = first launch, will show onboarding
+ */
+export interface OnboardingProgress {
+  completed: boolean;
+  skipped: boolean;
+  currentStep: number;  // 0-3: api-key, workspace, brand, instruction
+  visitedPages: {
+    settings: boolean;
+    launcher: boolean;
+  };
+}
+
+/**
  * App-level configuration
  */
 export interface AppConfig {
@@ -271,6 +285,10 @@ export interface AppConfig {
   imBotConfig?: import('../../shared/types/im').ImBotConfig;
   // Multi-bot configuration (v0.1.19+)
   imBotConfigs?: import('../../shared/types/im').ImBotConfig[];
+
+  // ===== Onboarding =====
+  // undefined = first launch (show onboarding); set after first run
+  onboarding?: OnboardingProgress;
 }
 
 /**

--- a/src/renderer/hooks/useConfig.ts
+++ b/src/renderer/hooks/useConfig.ts
@@ -228,6 +228,7 @@ export function useConfig(): UseConfigResult {
     const saveApiKey = useCallback(async (providerId: string, apiKey: string) => {
         await saveApiKeyService(providerId, apiKey);
         setApiKeys((prev) => ({ ...prev, [providerId]: apiKey }));
+        window.dispatchEvent(new Event(CUSTOM_EVENTS.CONFIG_CHANGED));
     }, []);
 
     const deleteApiKey = useCallback(async (providerId: string) => {

--- a/src/renderer/hooks/useOnboarding.ts
+++ b/src/renderer/hooks/useOnboarding.ts
@@ -1,0 +1,161 @@
+/**
+ * useOnboarding - Manages first-run guided onboarding state
+ *
+ * Loads progress from config.json on mount.
+ * undefined onboarding config = first launch = start at step 0.
+ * Listens for CONFIG_CHANGED to auto-advance steps 0 and 1.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { loadAppConfig, atomicModifyConfig } from '@/config/configService';
+import { type OnboardingProgress } from '@/config/types';
+import { CUSTOM_EVENTS, ONBOARDING_STEPS } from '../../shared/constants';
+
+export interface UseOnboardingResult {
+  isActive: boolean;
+  currentStep: number;
+  visitedPages: { settings: boolean; launcher: boolean };
+  markStepComplete: () => Promise<void>;
+  skipOnboarding: () => Promise<void>;
+  trackPageVisit: (page: 'settings' | 'launcher') => void;
+}
+
+export function useOnboarding(): UseOnboardingResult {
+  const [progress, setProgress] = useState<OnboardingProgress | null>(null);
+  const progressRef = useRef(progress);
+
+  // Sync ref in effect to avoid mutating during render
+  useEffect(() => {
+    progressRef.current = progress;
+  });
+
+  // Load onboarding progress on mount
+  useEffect(() => {
+    void loadAppConfig().then((config) => {
+      if (config.onboarding === undefined) {
+        // First launch: initialize onboarding at step 0
+        const initial: OnboardingProgress = {
+          completed: false,
+          skipped: false,
+          currentStep: ONBOARDING_STEPS.API_KEY,
+          visitedPages: { settings: false, launcher: false },
+        };
+        setProgress(initial);
+        // Persist initial state
+        void atomicModifyConfig((cfg) => ({ ...cfg, onboarding: initial }));
+      } else {
+        setProgress(config.onboarding);
+      }
+    });
+  }, []);
+
+  // Listen for CONFIG_CHANGED to auto-advance steps 0 and 1
+  useEffect(() => {
+    const handleConfigChanged = () => {
+      const current = progressRef.current;
+      if (!current || current.completed || current.skipped) return;
+
+      void loadAppConfig().then((config) => {
+        const cur = progressRef.current;
+        if (!cur || cur.completed || cur.skipped) return;
+
+        // Step 0: advance when first API key is added
+        if (cur.currentStep === ONBOARDING_STEPS.API_KEY) {
+          const hasKey = Object.keys(config.providerApiKeys ?? {}).length > 0;
+          if (hasKey) {
+            const next: OnboardingProgress = { ...cur, currentStep: ONBOARDING_STEPS.WORKSPACE };
+            setProgress(next);
+            void atomicModifyConfig((cfg) => ({ ...cfg, onboarding: next }));
+          }
+        }
+
+        // Step 1: advance when first workspace is added
+        if (cur.currentStep === ONBOARDING_STEPS.WORKSPACE) {
+          // We can't directly check projects here without loadProjects,
+          // but addProject fires CONFIG_CHANGED so we'll check projects.json
+          // via a side-effect. For simplicity, rely on ONBOARDING_WORKSPACE_ADDED event.
+        }
+      });
+    };
+
+    window.addEventListener(CUSTOM_EVENTS.CONFIG_CHANGED, handleConfigChanged);
+    return () => window.removeEventListener(CUSTOM_EVENTS.CONFIG_CHANGED, handleConfigChanged);
+  }, []);
+
+  // Listen for ONBOARDING_WORKSPACE_ADDED (fired by Launcher after addProject)
+  useEffect(() => {
+    const handleWorkspaceAdded = () => {
+      const cur = progressRef.current;
+      if (!cur || cur.completed || cur.skipped) return;
+      if (cur.currentStep !== ONBOARDING_STEPS.WORKSPACE) return;
+
+      const next: OnboardingProgress = { ...cur, currentStep: ONBOARDING_STEPS.BRAND };
+      setProgress(next);
+      void atomicModifyConfig((cfg) => ({ ...cfg, onboarding: next }));
+    };
+
+    window.addEventListener('onboarding:workspace-added', handleWorkspaceAdded);
+    return () => window.removeEventListener('onboarding:workspace-added', handleWorkspaceAdded);
+  }, []);
+
+  // Listen for ONBOARDING_INSTRUCTION_SUBMITTED (fired by Launcher on first send)
+  useEffect(() => {
+    const handleInstructionSubmitted = () => {
+      const cur = progressRef.current;
+      if (!cur || cur.completed || cur.skipped) return;
+      if (cur.currentStep !== ONBOARDING_STEPS.INSTRUCTION) return;
+
+      const next: OnboardingProgress = { ...cur, completed: true };
+      setProgress(next);
+      void atomicModifyConfig((cfg) => ({ ...cfg, onboarding: next }));
+    };
+
+    window.addEventListener(CUSTOM_EVENTS.ONBOARDING_INSTRUCTION_SUBMITTED, handleInstructionSubmitted);
+    return () => window.removeEventListener(CUSTOM_EVENTS.ONBOARDING_INSTRUCTION_SUBMITTED, handleInstructionSubmitted);
+  }, []);
+
+  const markStepComplete = useCallback(async () => {
+    const cur = progressRef.current;
+    if (!cur) return;
+
+    const nextStep = cur.currentStep + 1;
+    const completed = nextStep >= ONBOARDING_STEPS.TOTAL;
+    const next: OnboardingProgress = {
+      ...cur,
+      currentStep: completed ? cur.currentStep : nextStep,
+      completed,
+    };
+    setProgress(next);
+    await atomicModifyConfig((cfg) => ({ ...cfg, onboarding: next }));
+  }, []);
+
+  const skipOnboarding = useCallback(async () => {
+    const cur = progressRef.current;
+    if (!cur) return;
+    const next: OnboardingProgress = { ...cur, skipped: true, completed: true };
+    setProgress(next);
+    await atomicModifyConfig((cfg) => ({ ...cfg, onboarding: next }));
+  }, []);
+
+  const trackPageVisit = useCallback((page: 'settings' | 'launcher') => {
+    const cur = progressRef.current;
+    if (!cur || cur.visitedPages[page]) return;
+    const next: OnboardingProgress = {
+      ...cur,
+      visitedPages: { ...cur.visitedPages, [page]: true },
+    };
+    setProgress(next);
+    void atomicModifyConfig((cfg) => ({ ...cfg, onboarding: next }));
+  }, []);
+
+  const isActive = progress !== null && !progress.completed && !progress.skipped;
+
+  return {
+    isActive,
+    currentStep: progress?.currentStep ?? 0,
+    visitedPages: progress?.visitedPages ?? { settings: false, launcher: false },
+    markStepComplete,
+    skipOnboarding,
+    trackPageVisit,
+  };
+}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -56,6 +56,22 @@
   }
 }
 
+/* Onboarding tooltip zoom-in animation */
+@keyframes onboarding-appear {
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.animate-onboarding-appear {
+  animation: onboarding-appear 0.2s ease-out forwards;
+}
+
 /* Scroll anchoring for smoother streaming experience */
 .scroll-anchor-auto {
   overflow-anchor: auto;

--- a/src/renderer/pages/Launcher.tsx
+++ b/src/renderer/pages/Launcher.tsx
@@ -243,6 +243,8 @@ export default function Launcher({ onLaunchProject, isStarting, startError: _sta
             },
         }).catch(err => console.warn('[Launcher] Failed to save launcherLastUsed:', err));
 
+        // Notify onboarding that first instruction was submitted
+        window.dispatchEvent(new CustomEvent('onboarding:instruction-submitted'));
         setLaunchingProjectId(selectedWorkspace.id);
         touchProject(selectedWorkspace.id).catch(() => {});
         onLaunchProject(selectedWorkspace, launcherProvider, undefined, initialMessage);
@@ -350,6 +352,7 @@ export default function Launcher({ onLaunchProject, isStarting, startError: _sta
                     console.log('[Launcher] Adding project:', selected);
                     const project = await addProject(selected);
                     console.log('[Launcher] Project added:', project);
+                    window.dispatchEvent(new CustomEvent('onboarding:workspace-added'));
                 } else {
                     console.log('[Launcher] No folder selected or dialog cancelled');
                 }
@@ -369,6 +372,7 @@ export default function Launcher({ onLaunchProject, isStarting, startError: _sta
         try {
             const project = await addProject(path);
             console.log('[Launcher] Project added:', project);
+            window.dispatchEvent(new CustomEvent('onboarding:workspace-added'));
             // Normalize path separators for cross-platform support
             const normalizedPath = path.replace(/\\/g, '/');
             const parentDir = normalizedPath.split('/').slice(0, -1).join('/');
@@ -518,6 +522,7 @@ export default function Launcher({ onLaunchProject, isStarting, startError: _sta
                                     添加一个工作目录开始使用 Agent
                                 </p>
                                 <button
+                                    data-onboarding-id="add-workspace"
                                     onClick={handleAddProject}
                                     className="flex items-center gap-1.5 rounded-full bg-[var(--button-primary-bg)] px-5 py-2.5 text-[13px] font-medium text-[var(--button-primary-text)] transition-all hover:bg-[var(--button-primary-bg-hover)] hover:shadow-sm"
                                 >

--- a/src/renderer/pages/Launcher.tsx
+++ b/src/renderer/pages/Launcher.tsx
@@ -493,6 +493,7 @@ export default function Launcher({ onLaunchProject, isStarting, startError: _sta
                             )}
                             {projects.length > 0 && (
                                 <button
+                                    data-onboarding-id="add-workspace"
                                     onClick={handleAddProject}
                                     className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[13px] font-medium text-[var(--ink-muted)] transition-colors hover:bg-[var(--paper-contrast)] hover:text-[var(--ink)]"
                                 >

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -1360,7 +1360,7 @@ export default function Settings({ initialSection, onSectionChange, isActive, up
 
                 {/* Providers section uses wider layout */}
                 {activeSection === 'providers' && (
-                    <div className="mx-auto max-w-4xl px-8 py-8">
+                    <div data-onboarding-id="providers-section" className="mx-auto max-w-4xl px-8 py-8">
                         <div className="mb-8 flex items-center justify-between">
                             <h2 className="text-lg font-semibold text-[var(--ink)]">模型供应商</h2>
                             <button

--- a/src/server/git.ts
+++ b/src/server/git.ts
@@ -1,0 +1,326 @@
+import { execSync } from 'child_process';
+import { existsSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+// ============= TYPES =============
+
+export interface GitStatusFile {
+  path: string;
+  status: 'new' | 'modified' | 'deleted';
+}
+
+export interface GitStatusResult {
+  files: GitStatusFile[];
+  gitInitialized?: boolean;
+}
+
+export interface GitLogEntry {
+  hash: string;
+  message: string;
+  date: string;
+  author: string;
+  numFiles: number;
+}
+
+export interface GitLogResult {
+  entries: GitLogEntry[];
+  gitInitialized?: boolean;
+}
+
+export interface GitSubmitResult {
+  success: boolean;
+  hash?: string;
+  error?: string;
+}
+
+export interface GitInitResult {
+  initialized: boolean;
+}
+
+export interface GitRevertResult {
+  success: boolean;
+  error?: string;
+}
+
+// ============= HELPERS =============
+
+const DEFAULT_GITIGNORE = `node_modules
+.env
+*.log
+__pycache__
+.DS_Store
+dist
+build
+`;
+
+/**
+ * Run a git command in the given directory.
+ * Returns stdout string, or throws on error.
+ */
+function runGit(args: string[], cwd: string): string {
+  return execSync(['git', ...args].join(' '), {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+/**
+ * Check if the given directory has a .git folder (i.e. is a git repo root or child).
+ */
+function isGitRepo(workspacePath: string): boolean {
+  try {
+    runGit(['rev-parse', '--git-dir'], workspacePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Map a porcelain status code to our status type.
+ * Porcelain v1: two chars XY. We check index (X) and worktree (Y).
+ */
+function mapPorcelainCode(xy: string): GitStatusFile['status'] | null {
+  const x = xy[0] ?? ' ';
+  const y = xy[1] ?? ' ';
+
+  // Untracked
+  if (x === '?' && y === '?') return 'new';
+
+  // Deleted (from either index or worktree)
+  if (x === 'D' || y === 'D') return 'deleted';
+
+  // Added to index is also "new" from user perspective
+  if (x === 'A') return 'new';
+
+  // Any other modification
+  if (x !== ' ' || y !== ' ') return 'modified';
+
+  return null;
+}
+
+// ============= API HANDLERS =============
+
+/**
+ * GET /api/git/status
+ * Returns list of changed files in the workspace.
+ */
+export function handleGitStatus(workspacePath: string): GitStatusResult {
+  if (!isGitRepo(workspacePath)) {
+    return { files: [], gitInitialized: false };
+  }
+
+  try {
+    const output = runGit(['status', '--porcelain'], workspacePath);
+    const files: GitStatusFile[] = [];
+
+    for (const line of output.split('\n')) {
+      if (!line.trim()) continue;
+
+      const xy = line.substring(0, 2);
+      const filePath = line.substring(3).trim();
+
+      // Handle rename: "R old -> new" — porcelain shows "R  old\0new" but in v1 text it's "R  old -> new"
+      // We show the new path for renames
+      const displayPath = filePath.includes(' -> ')
+        ? filePath.split(' -> ')[1]!.trim()
+        : filePath;
+
+      const status = mapPorcelainCode(xy);
+      if (status && displayPath) {
+        files.push({ path: displayPath, status });
+      }
+    }
+
+    return { files };
+  } catch (error) {
+    console.error('[git] status error:', error);
+    return { files: [], gitInitialized: false };
+  }
+}
+
+/**
+ * GET /api/git/log
+ * Returns recent git log entries with file counts.
+ */
+export function handleGitLog(workspacePath: string): GitLogResult {
+  if (!isGitRepo(workspacePath)) {
+    return { entries: [], gitInitialized: false };
+  }
+
+  try {
+    // Get log in a parseable pipe-delimited format
+    const logOutput = runGit(
+      ['log', '--format=%H|%s|%ai|%an', '-n', '30'],
+      workspacePath
+    );
+
+    const entries: GitLogEntry[] = [];
+
+    for (const line of logOutput.split('\n')) {
+      if (!line.trim()) continue;
+
+      const parts = line.split('|');
+      if (parts.length < 4) continue;
+
+      const hash = parts[0]!.trim();
+      // Message may itself contain '|', so join remaining parts after first 3 splits
+      const message = parts.slice(1, parts.length - 2).join('|').trim();
+      const date = parts[parts.length - 2]!.trim();
+      const author = parts[parts.length - 1]!.trim();
+
+      // Count changed files for this commit
+      let numFiles = 0;
+      try {
+        const diffOutput = runGit(
+          ['diff-tree', '--no-commit-id', '-r', '--name-only', hash],
+          workspacePath
+        );
+        numFiles = diffOutput.split('\n').filter(l => l.trim()).length;
+      } catch {
+        // If diff-tree fails (e.g. root commit), leave 0
+      }
+
+      entries.push({ hash, message, date, author, numFiles });
+    }
+
+    return { entries };
+  } catch (error) {
+    console.error('[git] log error:', error);
+    return { entries: [], gitInitialized: false };
+  }
+}
+
+/**
+ * POST /api/git/submit
+ * Stage all changes and commit with the given message.
+ */
+export function handleGitSubmit(workspacePath: string, message?: string): GitSubmitResult {
+  const commitMessage = message?.trim() || 'Checkpoint';
+
+  try {
+    runGit(['add', '-A'], workspacePath);
+    runGit(['commit', '-m', JSON.stringify(commitMessage)], workspacePath);
+
+    // Get the hash of the new commit
+    const hash = runGit(['rev-parse', 'HEAD'], workspacePath).trim();
+    console.log(`[git] committed: ${hash} "${commitMessage}"`);
+
+    return { success: true, hash };
+  } catch (error) {
+    const errMsg = error instanceof Error ? error.message : String(error);
+    // "nothing to commit" is not an error worth surfacing as failure
+    if (errMsg.includes('nothing to commit')) {
+      return { success: false, error: 'Nothing to commit — workspace is clean.' };
+    }
+    console.error('[git] submit error:', error);
+    return { success: false, error: errMsg };
+  }
+}
+
+/**
+ * POST /api/git/init  (also callable from startup auto-init)
+ * Initialize a git repo, write a .gitignore, and set local user config.
+ */
+export function handleGitInit(workspacePath: string): GitInitResult {
+  try {
+    runGit(['init'], workspacePath);
+
+    // Write a default .gitignore if one doesn't exist
+    const gitignorePath = join(workspacePath, '.gitignore');
+    if (!existsSync(gitignorePath)) {
+      writeFileSync(gitignorePath, DEFAULT_GITIGNORE, 'utf-8');
+      console.log('[git] wrote default .gitignore');
+    }
+
+    // Set local user config if not already set
+    try {
+      runGit(['config', '--local', 'user.email', 'myagents@local'], workspacePath);
+    } catch {
+      // May fail if config already set globally — non-fatal
+    }
+    try {
+      runGit(['config', '--local', 'user.name', 'MyAgents'], workspacePath);
+    } catch {
+      // Non-fatal
+    }
+
+    console.log(`[git] initialized repo at ${workspacePath}`);
+    return { initialized: true };
+  } catch (error) {
+    console.error('[git] init error:', error);
+    throw error;
+  }
+}
+
+/**
+ * POST /api/git/revert
+ * Revert a single file or all changes in the workspace.
+ * - filePath provided: revert that specific file (checkout tracked, clean untracked)
+ * - filePath omitted:  revert all changes (checkout -- . && git clean -fd)
+ */
+export function handleGitRevert(workspacePath: string, filePath?: string): GitRevertResult {
+  if (!isGitRepo(workspacePath)) {
+    return { success: false, error: 'Not a git repository' };
+  }
+
+  try {
+    if (filePath) {
+      // Determine whether the file is tracked or untracked
+      const statusOutput = runGit(['status', '--porcelain', '--', filePath], workspacePath);
+      const xy = statusOutput.trim().substring(0, 2);
+      const isUntracked = xy === '??';
+
+      if (isUntracked) {
+        // Untracked (new) file — delete it with git clean
+        runGit(['clean', '-fd', '--', filePath], workspacePath);
+      } else {
+        // Tracked file (modified/deleted) — restore to HEAD
+        runGit(['checkout', 'HEAD', '--', filePath], workspacePath);
+      }
+      console.log(`[git] reverted file: ${filePath}`);
+    } else {
+      // Revert all: restore tracked files, remove untracked
+      runGit(['checkout', 'HEAD', '--', '.'], workspacePath);
+      runGit(['clean', '-fd'], workspacePath);
+      console.log('[git] reverted all changes');
+    }
+    return { success: true };
+  } catch (error) {
+    const errMsg = error instanceof Error ? error.message : String(error);
+    console.error('[git] revert error:', error);
+    return { success: false, error: errMsg };
+  }
+}
+
+/**
+ * Auto-initialize git for a workspace if it is not a temp path and has no .git directory.
+ * Called from server startup.
+ */
+export function autoInitGitRepo(workspacePath: string): void {
+  // Skip temp/system directories
+  const isTempPath =
+    workspacePath.startsWith('/tmp') ||
+    workspacePath.startsWith('/var/folders') ||
+    workspacePath.toLowerCase().includes('\\temp\\') ||
+    workspacePath.toLowerCase().includes('\\tmp\\');
+
+  if (isTempPath) {
+    console.log('[git] skipping auto-init for temp path:', workspacePath);
+    return;
+  }
+
+  // Skip if already a git repo
+  if (existsSync(join(workspacePath, '.git'))) {
+    return;
+  }
+
+  try {
+    handleGitInit(workspacePath);
+    console.log('[git] auto-initialized git repo at startup');
+  } catch (error) {
+    // Non-fatal — workspace is usable without git
+    console.warn('[git] auto-init failed (non-fatal):', error instanceof Error ? error.message : error);
+  }
+}

--- a/src/server/git.ts
+++ b/src/server/git.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { existsSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
@@ -58,7 +58,7 @@ build
  * Returns stdout string, or throws on error.
  */
 function runGit(args: string[], cwd: string): string {
-  return execSync(['git', ...args].join(' '), {
+  return execFileSync('git', args, {
     cwd,
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -201,7 +201,7 @@ export function handleGitSubmit(workspacePath: string, message?: string): GitSub
 
   try {
     runGit(['add', '-A'], workspacePath);
-    runGit(['commit', '-m', JSON.stringify(commitMessage)], workspacePath);
+    runGit(['commit', '-m', commitMessage], workspacePath);
 
     // Get the hash of the new commit
     const hash = runGit(['rev-parse', 'HEAD'], workspacePath).trim();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -126,6 +126,7 @@ import { cleanupOldUnifiedLogs, appendUnifiedLogBatch } from './UnifiedLogger';
 import { broadcast, createSseClient, getClients } from './sse';
 import { checkAnthropicSubscription, getGitBranch, verifyProviderViaSdk, verifySubscription } from './provider-verify';
 import { createBridgeHandler } from './openai-bridge';
+import { handleGitStatus, handleGitLog, handleGitSubmit, handleGitInit, handleGitRevert, autoInitGitRepo } from './git';
 
 type ImagePayload = {
   name: string;
@@ -648,6 +649,9 @@ async function main() {
   seedBundledSkills();
 
   await initializeAgent(currentAgentDir, initialPrompt, initialSessionId);
+
+  // Auto-initialize git repo for the workspace on startup (non-fatal)
+  autoInitGitRepo(currentAgentDir);
 
   // Store sidecar port for OpenAI bridge loopback
   setSidecarPort(port);
@@ -2557,6 +2561,51 @@ async function main() {
           console.error('[api/git/branch] Error:', error);
           return jsonResponse({ branch: null }, 200); // Non-fatal, just return null
         }
+      }
+
+      // GET /api/git/status - Get workspace git status (changed files)
+      if (pathname === '/api/git/status' && request.method === 'GET') {
+        const result = handleGitStatus(currentAgentDir);
+        return jsonResponse(result);
+      }
+
+      // GET /api/git/log - Get recent git commit history
+      if (pathname === '/api/git/log' && request.method === 'GET') {
+        const result = handleGitLog(currentAgentDir);
+        return jsonResponse(result);
+      }
+
+      // POST /api/git/submit - Stage all and commit
+      if (pathname === '/api/git/submit' && request.method === 'POST') {
+        const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+        const message = typeof body.message === 'string' ? body.message : undefined;
+        const workspacePath = typeof body.workspacePath === 'string' ? body.workspacePath : currentAgentDir;
+        const result = handleGitSubmit(workspacePath, message);
+        return jsonResponse(result);
+      }
+
+      // POST /api/git/init - Initialize git repo in workspace
+      if (pathname === '/api/git/init' && request.method === 'POST') {
+        const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+        const workspacePath = typeof body.workspacePath === 'string' ? body.workspacePath : currentAgentDir;
+        try {
+          const result = handleGitInit(workspacePath);
+          return jsonResponse(result);
+        } catch (error) {
+          return jsonResponse(
+            { initialized: false, error: error instanceof Error ? error.message : 'git init failed' },
+            500,
+          );
+        }
+      }
+
+      // POST /api/git/revert - Revert a single file or all changes
+      if (pathname === '/api/git/revert' && request.method === 'POST') {
+        const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+        const workspacePath = typeof body.workspacePath === 'string' ? body.workspacePath : currentAgentDir;
+        const filePath = typeof body.filePath === 'string' ? body.filePath : undefined;
+        const result = handleGitRevert(workspacePath, filePath);
+        return jsonResponse(result);
       }
 
       // GET /api/assets/qr-code - Fetch QR code image with local caching

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -85,4 +85,17 @@ export const CUSTOM_EVENTS = {
     // Note: CRON_TASK_STOPPED event removed
     // With Session-centric Sidecar (Owner model), stopping a cron task only releases
     // the CronTask owner. If Tab still owns the Sidecar, it continues running.
+    /** Fired when user submits first instruction during onboarding step 3 */
+    ONBOARDING_INSTRUCTION_SUBMITTED: 'onboarding:instruction-submitted',
+} as const;
+
+/**
+ * Onboarding step IDs (0-indexed)
+ */
+export const ONBOARDING_STEPS = {
+  API_KEY: 0,
+  WORKSPACE: 1,
+  BRAND: 2,
+  INSTRUCTION: 3,
+  TOTAL: 4,
 } as const;


### PR DESCRIPTION
## Summary

This PR contains exactly two features added to the fork, isolated from all upstream v0.1.25 changes (Task Center, PlanMode, etc.).

### 1. Workspace Changes Panel (v0.1.26)

- **Workspace Changes tab** in the sidebar showing git-tracked file diffs for the active workspace
- Per-file revert buttons — context-aware tooltip distinguishes deleted vs modified files
- Files tab refreshes immediately after revert/submit so restored files reappear without a manual reload

Commits: `a086bae`, `f680779`, `06bb1a2`

### 2. Guided Onboarding with Spotlight Overlay (v0.1.27)

- First-run onboarding flow with a spotlight overlay that highlights UI elements step-by-step
- Steps: welcome → add API key → add workspace → start chatting
- Persisted in config so it only shows once; skippable at any step
- Fixed spotlight positioning for the add-workspace step

Commits: `f621484`, `cf15652`

## What's excluded

All upstream v0.1.25 changes (Task Center, cron detail panel, ExitPlanMode card refactor, session tags, etc.) are intentionally excluded — this branch is based on `ad93105` (upstream v0.1.25 merge point) with only the above 5 commits cherry-picked on top.

## Test plan

- [ ] Fresh install (no existing config): onboarding overlay appears on first launch, steps through correctly, spotlight highlights the right elements
- [ ] Add workspace step: spotlight correctly targets the workspace button
- [ ] Repeat launch: onboarding does not appear again after completion
- [ ] Workspace with git changes: Changes tab shows modified/deleted files with correct icons
- [ ] Revert a modified file: file disappears from Changes tab, reappears in Files tab
- [ ] Revert a deleted file: file reappears in Files tab immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)